### PR TITLE
feat: image preview with next/pre button

### DIFF
--- a/frontend/src/components/image-preview.tsx
+++ b/frontend/src/components/image-preview.tsx
@@ -1,14 +1,30 @@
 'use client';
 
 import { useState, useRef, useEffect, MouseEvent, TouchEvent } from 'react';
-import { X, ZoomIn, ZoomOut, RotateCw, Download } from 'lucide-react';
+import { X, ZoomIn, ZoomOut, RotateCw, Download, ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface ImagePreviewProps {
   src: string;
+  images?: string[];
+  currentIndex?: number;
   onClose: () => void;
+  onIndexChange?: (index: number) => void;
 }
 
-export function ImagePreview({ src, onClose }: ImagePreviewProps) {
+export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexChange }: ImagePreviewProps) {
+  const hasMultiple = images && images.length > 1;
+
+  const goToPrev = () => {
+    if (!images || !onIndexChange) return;
+    const newIndex = currentIndex > 0 ? currentIndex - 1 : images.length - 1;
+    onIndexChange(newIndex);
+  };
+
+  const goToNext = () => {
+    if (!images || !onIndexChange) return;
+    const newIndex = currentIndex < images.length - 1 ? currentIndex + 1 : 0;
+    onIndexChange(newIndex);
+  };
   const [scale, setScale] = useState(1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [rotation, setRotation] = useState(0);
@@ -145,12 +161,18 @@ export function ImagePreview({ src, onClose }: ImagePreviewProps) {
         case '0':
           handleReset();
           break;
+        case 'ArrowLeft':
+          if (hasMultiple) goToPrev();
+          break;
+        case 'ArrowRight':
+          if (hasMultiple) goToNext();
+          break;
       }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose]);
+  }, [onClose, hasMultiple, currentIndex]);
 
   return (
     <div
@@ -206,6 +228,35 @@ export function ImagePreview({ src, onClose }: ImagePreviewProps) {
         {Math.round(scale * 100)}%
       </div>
 
+      {/* Prev button */}
+      {hasMultiple && (
+        <button
+          onClick={(e) => { e.stopPropagation(); goToPrev(); }}
+          className="absolute left-4 top-1/2 -translate-y-1/2 z-10 p-2 bg-white/10 hover:bg-white/20 rounded-full backdrop-blur-sm transition-colors"
+          title="上一张 (←)"
+        >
+          <ChevronLeft className="w-6 h-6 text-white" />
+        </button>
+      )}
+
+      {/* Next button */}
+      {hasMultiple && (
+        <button
+          onClick={(e) => { e.stopPropagation(); goToNext(); }}
+          className="absolute right-4 top-1/2 -translate-y-1/2 z-10 p-2 bg-white/10 hover:bg-white/20 rounded-full backdrop-blur-sm transition-colors"
+          title="下一张 (→)"
+        >
+          <ChevronRight className="w-6 h-6 text-white" />
+        </button>
+      )}
+
+      {/* Image counter */}
+      {hasMultiple && (
+        <div className="absolute bottom-14 left-1/2 transform -translate-x-1/2 px-3 py-1.5 bg-white/10 rounded-lg backdrop-blur-sm text-white text-sm">
+          {currentIndex + 1} / {images.length}
+        </div>
+      )}
+
       {/* Image container */}
       <div
         className="relative w-full h-full flex items-center justify-center overflow-hidden"
@@ -228,7 +279,7 @@ export function ImagePreview({ src, onClose }: ImagePreviewProps) {
 
       {/* Instructions */}
       <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 px-4 py-2 bg-white/10 rounded-lg backdrop-blur-sm text-white text-sm text-center">
-        拖拽移动 | 滚轮缩放 | +/- 缩放 | R 旋转 | 0 重置 | ESC 关闭
+        拖拽移动 | 滚轮缩放 | +/- 缩放 | R 旋转 | 0 重置 | ESC 关闭{hasMultiple ? ' | ←/→ 切换' : ''}
       </div>
     </div>
   );

--- a/frontend/src/components/image-preview.tsx
+++ b/frontend/src/components/image-preview.tsx
@@ -12,7 +12,7 @@ interface ImagePreviewProps {
 }
 
 export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexChange }: ImagePreviewProps) {
-  const hasMultiple = images && images.length > 1;
+  const hasMultiple = (images?.length ?? 0) > 1;
 
   const goToPrev = useCallback(() => {
     if (!images || !onIndexChange) return;

--- a/frontend/src/components/image-preview.tsx
+++ b/frontend/src/components/image-preview.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useEffect, MouseEvent, TouchEvent } from 'react';
+import { useState, useRef, useEffect, useCallback, MouseEvent, TouchEvent } from 'react';
 import { X, ZoomIn, ZoomOut, RotateCw, Download, ChevronLeft, ChevronRight } from 'lucide-react';
 
 interface ImagePreviewProps {
@@ -14,17 +14,18 @@ interface ImagePreviewProps {
 export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexChange }: ImagePreviewProps) {
   const hasMultiple = images && images.length > 1;
 
-  const goToPrev = () => {
+  const goToPrev = useCallback(() => {
     if (!images || !onIndexChange) return;
     const newIndex = currentIndex > 0 ? currentIndex - 1 : images.length - 1;
     onIndexChange(newIndex);
-  };
+  }, [images, onIndexChange, currentIndex]);
 
-  const goToNext = () => {
+  const goToNext = useCallback(() => {
     if (!images || !onIndexChange) return;
     const newIndex = currentIndex < images.length - 1 ? currentIndex + 1 : 0;
     onIndexChange(newIndex);
-  };
+  }, [images, onIndexChange, currentIndex]);
+
   const [scale, setScale] = useState(1);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [rotation, setRotation] = useState(0);
@@ -34,6 +35,11 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
   const imageRef = useRef<HTMLImageElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Touch gesture refs
+  const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
+  const pinchStartDistRef = useRef<number | null>(null);
+  const pinchStartScaleRef = useRef(1);
+
   // Reset on image change
   useEffect(() => {
     setScale(1);
@@ -41,13 +47,25 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
     setRotation(0);
   }, [src]);
 
+  // Lock body scroll when preview is open
+  useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
+    const originalTouchAction = document.body.style.touchAction;
+    document.body.style.overflow = 'hidden';
+    document.body.style.touchAction = 'none';
+    return () => {
+      document.body.style.overflow = originalOverflow;
+      document.body.style.touchAction = originalTouchAction;
+    };
+  }, []);
+
   // Handle zoom
-  const handleZoom = (delta: number) => {
+  const handleZoom = useCallback((delta: number) => {
     setScale((prev) => {
       const newScale = prev + delta;
       return Math.max(0.1, Math.min(5, newScale));
     });
-  };
+  }, []);
 
   // Handle wheel zoom with native event listener to prevent passive behavior
   useEffect(() => {
@@ -62,11 +80,11 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
 
     container.addEventListener('wheel', handleWheel, { passive: false });
     return () => container.removeEventListener('wheel', handleWheel);
-  }, []);
+  }, [handleZoom]);
 
   // Handle mouse drag start
   const handleMouseDown = (e: MouseEvent<HTMLDivElement>) => {
-    if (e.button !== 0) return; // Only left click
+    if (e.button !== 0) return;
     setIsDragging(true);
     setDragStart({
       x: e.clientX - position.x,
@@ -87,18 +105,47 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
     setIsDragging(false);
   };
 
-  // Handle touch events for mobile
+  // Touch: compute distance between two touches
+  const getTouchDistance = (t1: globalThis.Touch, t2: globalThis.Touch) => {
+    const dx = t1.clientX - t2.clientX;
+    const dy = t1.clientY - t2.clientY;
+    return Math.sqrt(dx * dx + dy * dy);
+  };
+
+  // Handle touch events for mobile (swipe + pinch + drag)
   const handleTouchStart = (e: TouchEvent<HTMLDivElement>) => {
-    if (e.touches.length === 1) {
-      setIsDragging(true);
-      setDragStart({
-        x: e.touches[0].clientX - position.x,
-        y: e.touches[0].clientY - position.y,
-      });
+    if (e.touches.length === 2) {
+      // Pinch start
+      pinchStartDistRef.current = getTouchDistance(e.touches[0], e.touches[1]);
+      pinchStartScaleRef.current = scale;
+      setIsDragging(false);
+    } else if (e.touches.length === 1) {
+      // Record for swipe detection + drag
+      touchStartRef.current = {
+        x: e.touches[0].clientX,
+        y: e.touches[0].clientY,
+        time: Date.now(),
+      };
+      // Only enable drag when zoomed in
+      if (scale > 1) {
+        setIsDragging(true);
+        setDragStart({
+          x: e.touches[0].clientX - position.x,
+          y: e.touches[0].clientY - position.y,
+        });
+      }
     }
   };
 
   const handleTouchMove = (e: TouchEvent<HTMLDivElement>) => {
+    if (e.touches.length === 2 && pinchStartDistRef.current !== null) {
+      // Pinch zoom
+      const currentDist = getTouchDistance(e.touches[0], e.touches[1]);
+      const ratio = currentDist / pinchStartDistRef.current;
+      const newScale = Math.max(0.1, Math.min(5, pinchStartScaleRef.current * ratio));
+      setScale(newScale);
+      return;
+    }
     if (!isDragging || e.touches.length !== 1) return;
     setPosition({
       x: e.touches[0].clientX - dragStart.x,
@@ -106,8 +153,33 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
     });
   };
 
-  const handleTouchEnd = () => {
+  const handleTouchEnd = (e: TouchEvent<HTMLDivElement>) => {
+    // Pinch end
+    if (pinchStartDistRef.current !== null && e.touches.length < 2) {
+      pinchStartDistRef.current = null;
+      return;
+    }
+
     setIsDragging(false);
+
+    // Swipe detection (only when not zoomed in)
+    if (scale <= 1 && touchStartRef.current && hasMultiple) {
+      const dx = (e.changedTouches[0]?.clientX ?? 0) - touchStartRef.current.x;
+      const dy = (e.changedTouches[0]?.clientY ?? 0) - touchStartRef.current.y;
+      const dt = Date.now() - touchStartRef.current.time;
+      const absDx = Math.abs(dx);
+      const absDy = Math.abs(dy);
+
+      // Horizontal swipe: >60px, mostly horizontal, within 300ms
+      if (absDx > 60 && absDx > absDy * 1.5 && dt < 300) {
+        if (dx > 0) {
+          goToPrev();
+        } else {
+          goToNext();
+        }
+      }
+    }
+    touchStartRef.current = null;
   };
 
   // Handle rotation
@@ -172,12 +244,12 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onClose, hasMultiple, currentIndex]);
+  }, [onClose, hasMultiple, goToPrev, goToNext, handleZoom]);
 
   return (
     <div
       ref={containerRef}
-      className="fixed inset-0 bg-black z-[9999] flex items-center justify-center"
+      className="fixed inset-0 z-[100] bg-black/95 select-none"
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseUp}
@@ -185,38 +257,38 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
       onTouchEnd={handleTouchEnd}
     >
       {/* Toolbar */}
-      <div className="absolute top-4 right-4 flex gap-2 z-10">
+      <div className="absolute top-4 right-4 z-20 flex gap-2">
         <button
           onClick={() => handleZoom(0.2)}
-          className="p-2 bg-white/10 hover:bg-white/20 rounded-lg backdrop-blur-sm transition-colors"
+          className="p-2.5 sm:p-2 bg-white/10 hover:bg-white/20 active:bg-white/30 rounded-lg backdrop-blur-sm transition-colors"
           title="放大 (+)"
         >
           <ZoomIn className="w-5 h-5 text-white" />
         </button>
         <button
           onClick={() => handleZoom(-0.2)}
-          className="p-2 bg-white/10 hover:bg-white/20 rounded-lg backdrop-blur-sm transition-colors"
+          className="p-2.5 sm:p-2 bg-white/10 hover:bg-white/20 active:bg-white/30 rounded-lg backdrop-blur-sm transition-colors"
           title="缩小 (-)"
         >
           <ZoomOut className="w-5 h-5 text-white" />
         </button>
         <button
           onClick={handleRotate}
-          className="p-2 bg-white/10 hover:bg-white/20 rounded-lg backdrop-blur-sm transition-colors"
+          className="p-2.5 sm:p-2 bg-white/10 hover:bg-white/20 active:bg-white/30 rounded-lg backdrop-blur-sm transition-colors"
           title="旋转 (R)"
         >
           <RotateCw className="w-5 h-5 text-white" />
         </button>
         <button
           onClick={handleDownload}
-          className="p-2 bg-white/10 hover:bg-white/20 rounded-lg backdrop-blur-sm transition-colors"
+          className="p-2.5 sm:p-2 bg-white/10 hover:bg-white/20 active:bg-white/30 rounded-lg backdrop-blur-sm transition-colors"
           title="下载"
         >
           <Download className="w-5 h-5 text-white" />
         </button>
         <button
           onClick={onClose}
-          className="p-2 bg-white/10 hover:bg-white/20 rounded-lg backdrop-blur-sm transition-colors"
+          className="p-2.5 sm:p-2 bg-white/10 hover:bg-white/20 active:bg-white/30 rounded-lg backdrop-blur-sm transition-colors"
           title="关闭 (ESC)"
         >
           <X className="w-5 h-5 text-white" />
@@ -232,7 +304,7 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
       {hasMultiple && (
         <button
           onClick={(e) => { e.stopPropagation(); goToPrev(); }}
-          className="absolute left-4 top-1/2 -translate-y-1/2 z-10 p-2 bg-white/10 hover:bg-white/20 rounded-full backdrop-blur-sm transition-colors"
+          className="absolute left-2 sm:left-4 top-1/2 -translate-y-1/2 z-10 p-3 sm:p-2 bg-white/10 hover:bg-white/20 active:bg-white/30 rounded-full backdrop-blur-sm transition-colors"
           title="上一张 (←)"
         >
           <ChevronLeft className="w-6 h-6 text-white" />
@@ -243,7 +315,7 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
       {hasMultiple && (
         <button
           onClick={(e) => { e.stopPropagation(); goToNext(); }}
-          className="absolute right-4 top-1/2 -translate-y-1/2 z-10 p-2 bg-white/10 hover:bg-white/20 rounded-full backdrop-blur-sm transition-colors"
+          className="absolute right-2 sm:right-4 top-1/2 -translate-y-1/2 z-10 p-3 sm:p-2 bg-white/10 hover:bg-white/20 active:bg-white/30 rounded-full backdrop-blur-sm transition-colors"
           title="下一张 (→)"
         >
           <ChevronRight className="w-6 h-6 text-white" />
@@ -268,7 +340,7 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
           ref={imageRef}
           src={src}
           alt="Preview"
-          className="max-w-none select-none"
+          className="max-w-[90vw] max-h-[85vh] sm:max-w-none sm:max-h-none object-contain select-none"
           draggable={false}
           style={{
             transform: `translate(${position.x}px, ${position.y}px) scale(${scale}) rotate(${rotation}deg)`,
@@ -277,9 +349,14 @@ export function ImagePreview({ src, images, currentIndex = 0, onClose, onIndexCh
         />
       </div>
 
-      {/* Instructions */}
-      <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 px-4 py-2 bg-white/10 rounded-lg backdrop-blur-sm text-white text-sm text-center">
+      {/* Instructions - desktop only */}
+      <div className="hidden sm:block absolute bottom-4 left-1/2 transform -translate-x-1/2 px-4 py-2 bg-white/10 rounded-lg backdrop-blur-sm text-white text-sm text-center">
         拖拽移动 | 滚轮缩放 | +/- 缩放 | R 旋转 | 0 重置 | ESC 关闭{hasMultiple ? ' | ←/→ 切换' : ''}
+      </div>
+
+      {/* Instructions - mobile only */}
+      <div className="sm:hidden absolute bottom-4 left-1/2 transform -translate-x-1/2 px-4 py-2 bg-white/10 rounded-lg backdrop-blur-sm text-white text-xs text-center">
+        双指缩放 | 拖拽移动{hasMultiple ? ' | 左右滑动切换' : ''}
       </div>
     </div>
   );

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -95,7 +95,7 @@ export function PostCard({ data, isLoggedIn = false, emojiUpdates, archiveUpdate
   const contentRef = useRef<HTMLDivElement>(null);
   const [scrollEnd, setScrollEnd] = useState(true);
   const [showImageModal, setShowImageModal] = useState(false);
-  const [previewImage, setPreviewImage] = useState<string | null>(null);
+  const [previewImage, setPreviewImage] = useState<number | null>(null);
   const [isArchived, setIsArchived] = useState(data.is_archive);
 
   // 3D tilt state (using ref to avoid re-renders)
@@ -446,7 +446,7 @@ export function PostCard({ data, isLoggedIn = false, emojiUpdates, archiveUpdate
                     src={image}
                     alt={`Image ${index + 1}`}
                     className="absolute top-0 left-0 w-full h-full object-cover transition-transform hover:scale-105"
-                    onClick={() => setPreviewImage(image)}
+                    onClick={() => setPreviewImage(index)}
                   />
                 </div>
               ))}
@@ -456,10 +456,13 @@ export function PostCard({ data, isLoggedIn = false, emojiUpdates, archiveUpdate
       )}
 
       {/* Full Image Preview */}
-      {previewImage && (
+      {previewImage !== null && (
         <ImagePreview
-          src={previewImage}
+          src={imageList[previewImage]}
+          images={imageList}
+          currentIndex={previewImage}
           onClose={() => setPreviewImage(null)}
+          onIndexChange={(index) => setPreviewImage(index)}
         />
       )}
 


### PR DESCRIPTION
图片预览组件应当提供 上一张/下一张 图片的切换按钮

## Summary by Sourcery

Add multi-image navigation and improved touch/keyboard interactions to the image preview modal and integrate it with post cards for gallery-style viewing.

New Features:
- Enable the image preview component to accept an image list and current index, supporting previous/next navigation with buttons, keyboard arrows, and swipe gestures.
- Display an image counter overlay in the preview modal when viewing multiple images.

Enhancements:
- Improve mobile and desktop interaction in the image preview with pinch-to-zoom, refined drag behavior, and separate instruction hints per device type.
- Lock body scrolling while the image preview modal is open and adjust layout/styling for better responsiveness and readability.
- Wire post cards to open the image preview as a gallery, allowing cycling through all images in a post.