### PR TITLE
fix: card link render

### DIFF
--- a/admin/src/app/dashboard/questions/page.tsx
+++ b/admin/src/app/dashboard/questions/page.tsx
@@ -67,7 +67,7 @@ function renderContent(content: string) {
   );
   // Replace URLs with links
   rendered = rendered.replace(
-    /https?:\/\/[^\s<]+/g,
+    /https?:\/\/[^\s<\[]+/g,
     (match) => `<a href="${match}" target="_blank" rel="noopener noreferrer" style="color:#00a1d6;text-decoration:underline;">${match}</a>`
   );
   // Replace BV codes with bilibili links (only if not already linked)

--- a/frontend/src/components/post-card.tsx
+++ b/frontend/src/components/post-card.tsx
@@ -51,7 +51,7 @@ function renderContent(content: string): string {
   );
   // Replace URLs with links
   rendered = rendered.replace(
-    /https?:\/\/[^\s<]+/g,
+    /https?:\/\/[^\s<\[]+/g,
     (match) => `<a href="${match}" target="_blank" rel="noopener noreferrer" style="color:#00a1d6;text-decoration:underline;">${match}</a>`
   );
   // Replace BV codes with bilibili links (only if not already linked)


### PR DESCRIPTION
卡片在渲染时，同时有网址和表情 emoji，渲染会出错，最终得到的元素：
```html
<a href="https://d8500643.pinit.eth.limo&lt;img src=" joi-emojis="" tietie.webp"="" alt="[轴伊Joi收藏集动态表情包\_贴贴]" style="display:inline-block;height:64px;width:64px;vertical-align:middle;margin:0 2px;object-fit:contain;">" target="\_blank" rel="noopener noreferrer" style="color:#00a1d6;text-decoration:underline;"&gt;https://d8500643.pinit.eth.limo<img src="/joi-emojis/tietie.webp" alt="[轴伊Joi收藏集动态表情包\_贴贴]" style="display:inline-block;height:64px;width:64px;vertical-align:middle;margin:0 2px;object-fit:contain;"></a>
```

## Summary by Sourcery

Bug Fixes:
- Fix incorrect link rendering where trailing emoji or bracketed content was captured as part of the URL in cards and dashboard question content.