### PR TITLE
后台延迟展示匿名投稿者身份

### DIFF
--- a/admin/src/app/dashboard/questions/questions-page-content.tsx
+++ b/admin/src/app/dashboard/questions/questions-page-content.tsx
@@ -54,6 +54,83 @@ function formatDate(dateString: string) {
   return new Date(dateString).toLocaleString("zh-CN");
 }
 
+const IDENTITY_REVEAL_DELAY_SECONDS = 5;
+
+function AnonymousSubmitter({ question }: { question: Question }) {
+  const [isHovering, setIsHovering] = useState(false);
+  const [countdown, setCountdown] = useState(IDENTITY_REVEAL_DELAY_SECONDS);
+  const [isRevealed, setIsRevealed] = useState(false);
+
+  useEffect(() => {
+    if (!isHovering || isRevealed) return;
+
+    const timer = window.setInterval(() => {
+      setCountdown((current) => {
+        if (current <= 1) {
+          window.clearInterval(timer);
+          setIsRevealed(true);
+          return 0;
+        }
+        return current - 1;
+      });
+    }, 1000);
+
+    return () => window.clearInterval(timer);
+  }, [isHovering, isRevealed]);
+
+  const showTip = () => setIsHovering(true);
+  const hideTip = () => {
+    setIsHovering(false);
+    setCountdown(IDENTITY_REVEAL_DELAY_SECONDS);
+    setIsRevealed(false);
+  };
+
+  return (
+    <span
+      className="relative inline-flex cursor-help text-muted-foreground"
+      tabIndex={0}
+      onMouseEnter={showTip}
+      onMouseLeave={hideTip}
+      onFocus={showTip}
+      onBlur={hideTip}
+    >
+      匿名
+      {isHovering && (
+        <span
+          role="tooltip"
+          className="pointer-events-none absolute bottom-full left-1/2 z-50 mb-2 w-max max-w-[260px] -translate-x-1/2 rounded-md border bg-popover px-3 py-2 text-xs text-popover-foreground shadow-md"
+        >
+          {isRevealed ? (
+            question.bilibili_uid ? (
+              <span className="flex items-center gap-2">
+                {question.bilibili_avatar && (
+                  <img
+                    src={question.bilibili_avatar}
+                    alt=""
+                    className="h-7 w-7 shrink-0 rounded-full object-cover"
+                  />
+                )}
+                <span className="flex min-w-0 flex-col">
+                  <span className="max-w-[190px] truncate font-medium">
+                    {question.bilibili_name || "已登录用户"}
+                  </span>
+                  <span className="text-muted-foreground">
+                    UID {question.bilibili_uid}
+                  </span>
+                </span>
+              </span>
+            ) : (
+              "未登录投稿，无身份信息"
+            )
+          ) : (
+            <>身份将在 {countdown} 秒后显示</>
+          )}
+        </span>
+      )}
+    </span>
+  );
+}
+
 const EMOJI_MAP: Record<string, string> = {
   '[轴伊Joi收藏集动态表情包_跑了]': '/joi-emojis/paole.webp',
   '[轴伊Joi收藏集动态表情包_鞠躬]': '/joi-emojis/jugong.webp',
@@ -474,7 +551,7 @@ export function QuestionsPageContent({ isSpam }: QuestionsPageContentProps) {
                           {question.bilibili_avatar && <img src={question.bilibili_avatar} alt="" className="h-7 w-7 shrink-0 rounded-full object-cover" />}
                           <span className="truncate" title={`UID ${question.bilibili_uid}`}>{question.bilibili_name}</span>
                         </a>
-                      ) : <span className="text-muted-foreground">匿名</span>}
+                      ) : <AnonymousSubmitter question={question} />}
                     </TableCell>
                     <TableCell className="text-center text-sm whitespace-nowrap">
                       {question.images_num}

--- a/admin/src/lib/api.ts
+++ b/admin/src/lib/api.ts
@@ -181,7 +181,7 @@ export async function getQuestions(params: {
   if (params.tag_id) searchParams.set('tag_id', params.tag_id.toString());
   if (params.is_spam !== undefined) searchParams.set('is_spam', params.is_spam.toString());
 
-  const res = await fetch(`${API_BASE}/question?${searchParams.toString()}`, {
+  const res = await fetch(`${API_BASE}/admin/question?${searchParams.toString()}`, {
     method: 'GET',
     credentials: 'include',
   });

--- a/internal/controller/question_controller.go
+++ b/internal/controller/question_controller.go
@@ -128,12 +128,29 @@ type QuestionModifyRequest struct {
 	IsSpam    *bool `json:"is_spam"`
 }
 
+type questionWithIdentityAlias database.Question
+
+type questionWithIdentity struct {
+	questionWithIdentityAlias
+	BilibiliUID *string `json:"bilibili_uid,omitempty"`
+}
+
 // Get questions
 func (*QuestionController) Get(c *gin.Context) {
 	// Prepare for auth
 	if sessions.Default(c).Get("authed") == true {
 		c.Set("authed", true)
 	}
+	getQuestions(c, false)
+}
+
+// GetWithIdentity returns submitter identities only through the authenticated
+// admin route. The public response continues to use Question.MarshalJSON.
+func (*QuestionController) GetWithIdentity(c *gin.Context) {
+	getQuestions(c, true)
+}
+
+func getQuestions(c *gin.Context, includeIdentity bool) {
 	var questionList []database.Question
 	var total int64
 	var request QuestionRequest
@@ -185,12 +202,62 @@ func (*QuestionController) Get(c *gin.Context) {
 		Fail(c, 500, "获取提问失败")
 		return
 	}
+	questions := any(questionList)
+	if includeIdentity {
+		questions = questionsWithIdentity(questionList)
+	}
 	Success(c, gin.H{
-		"questions": questionList,
+		"questions": questions,
 		"total":     total,
 		"page":      getPage(request.Page),
 		"page_size": getPageSize(request.PageSize),
 	})
+}
+
+func questionsWithIdentity(questions []database.Question) []questionWithIdentity {
+	uids := make([]int64, 0, len(questions))
+	for _, question := range questions {
+		if question.BilibiliUID != nil && (question.BilibiliName == "" || question.BilibiliAvatar == "") {
+			uids = append(uids, *question.BilibiliUID)
+		}
+	}
+
+	members := make(map[int64]database.User, len(uids))
+	if len(uids) > 0 {
+		var users []database.User
+		if err := database.DB.Where("bilibili_uid IN ?", uids).Find(&users).Error; err != nil {
+			log.Error("Failed to load question submitter identities: ", err)
+		}
+		for _, user := range users {
+			members[user.BilibiliUID] = user
+		}
+	}
+
+	result := make([]questionWithIdentity, 0, len(questions))
+	for i := range questions {
+		question := questions[i]
+		if question.BilibiliUID != nil {
+			if member, ok := members[*question.BilibiliUID]; ok {
+				if question.BilibiliName == "" {
+					question.BilibiliName = member.BilibiliName
+				}
+				if question.BilibiliAvatar == "" {
+					question.BilibiliAvatar = member.BilibiliAvatar
+				}
+			}
+		}
+
+		var uid *string
+		if question.BilibiliUID != nil {
+			value := strconv.FormatInt(*question.BilibiliUID, 10)
+			uid = &value
+		}
+		result = append(result, questionWithIdentity{
+			questionWithIdentityAlias: questionWithIdentityAlias(question),
+			BilibiliUID:               uid,
+		})
+	}
+	return result
 }
 
 func (this *QuestionController) Put(c *gin.Context) {
@@ -256,11 +323,11 @@ func (*QuestionController) Post(c *gin.Context) {
 	var q database.Question
 	if memberLoggedIn {
 		q.BilibiliUID = &member.BilibiliUID
+		q.BilibiliName = member.BilibiliName
+		q.BilibiliAvatar = member.BilibiliAvatar
 	}
 	if realName {
 		q.IsRealName = true
-		q.BilibiliName = member.BilibiliName
-		q.BilibiliAvatar = member.BilibiliAvatar
 	}
 	q.TagID = int(tag.ID)
 	q.Content = strings.Trim(c.PostForm("content"), " \r\n\t")

--- a/internal/controller/question_controller_test.go
+++ b/internal/controller/question_controller_test.go
@@ -1,0 +1,51 @@
+package controller
+
+import (
+	"encoding/json"
+	"joiask-backend/internal/database"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestQuestionsWithIdentityEnrichesAnonymousSubmitter(t *testing.T) {
+	var err error
+	database.DB, err = gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "question.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.DB.AutoMigrate(&database.User{}); err != nil {
+		t.Fatal(err)
+	}
+
+	uid := int64(123456)
+	if err := database.DB.Create(&database.User{
+		BilibiliUID:    uid,
+		Username:       "member",
+		PasswordHash:   "hash",
+		BilibiliName:   "测试用户",
+		BilibiliAvatar: "/upload-img/avatar.jpg",
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	response, err := json.Marshal(questionsWithIdentity([]database.Question{{
+		BilibiliUID: &uid,
+		IsRealName:  false,
+	}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, expected := range []string{
+		`"bilibili_uid":"123456"`,
+		`"bilibili_name":"测试用户"`,
+		`"bilibili_avatar":"/upload-img/avatar.jpg"`,
+	} {
+		if !strings.Contains(string(response), expected) {
+			t.Fatalf("admin question missing %s: %s", expected, response)
+		}
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -102,6 +102,7 @@ func Run() {
 		// Question
 		{
 			api.GET("/question", questionController.Get)
+			api.GET("/admin/question", authMiddleware, questionController.GetWithIdentity)
 			api.POST("/question", questionController.Post)
 			api.PUT("/question/:id", authMiddleware, questionController.Put)
 			api.POST("/question/:id/emoji", questionController.Emoji)


### PR DESCRIPTION
## 变更内容
- 为后台匿名投稿者增加带 5 秒倒计时的 hover 提示
- 倒计时结束后展示投稿者昵称、头像和 B 站 UID
- 增加仅管理员认证可访问的身份版提问接口，公开接口继续隐藏匿名身份
- 为新投稿保存身份快照，并通过 UID 补全历史匿名投稿的会员资料
- 增加匿名投稿者身份补全测试

## 验证
- `go test ./...`
- `npm --prefix admin run build`
- 完整本地环境手动验证倒计时、身份展示与公开接口隐私隔离